### PR TITLE
 Filtrar Notificações Por Fila do Usuário 

### DIFF
--- a/frontend/src/components/NotificationsPopOver/index.js
+++ b/frontend/src/components/NotificationsPopOver/index.js
@@ -108,10 +108,13 @@ const NotificationsPopOver = () => {
 		});
 
 		socket.on("appMessage", data => {
+			const UserQueues = user.queues.findIndex((users) => (users.id === data.ticket.queueId));
 			if (
-				data.action === "create" &&
+				(data.action === "create" &&
 				!data.message.read &&
 				(data.ticket.userId === user?.id || !data.ticket.userId)
+				&& (UserQueues !== -1 || !data.ticket.queueId))
+				 //||data.ticket.isGroup
 			) {
 				setNotifications(prevState => {
 					const ticketIndex = prevState.findIndex(t => t.id === data.ticket.id);


### PR DESCRIPTION
Ao Notificar as mensagens estava aparecendo para todos os usuários, criado para notificar somente os usuários pertencentes a fila do ticket